### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Safely connect your devices to Aloes backend, register your sensors wi
 category=Device Control
 url=https://github.com/getlarge/arduino-device-mqtt
 architectures=esp8266, esp32
+depends=ArduinoJson, advancedSerial, Bounce2, WiFiManager, PubSubClient


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format